### PR TITLE
colors: address #118 and some improvements

### DIFF
--- a/src/luaotfload-colors.lua
+++ b/src/luaotfload-colors.lua
@@ -226,8 +226,7 @@ local function node_colorize (head, current_color, nested)
         if n_id == hlist_t or n_id == vlist_t then
             local n_list = getlist(n)
             if  color_props(n_list).box_colored or
-                color_props(getnext(n_list)).box_colored or
-                color_props(getnext(getnext(n_list))).box_colored then
+                color_props(getnext(n_list)).box_colored then
                 if current_color then
                     head, n, current_color = color_whatsit(head, n, current_color, false)
                 end

--- a/src/luaotfload-colors.lua
+++ b/src/luaotfload-colors.lua
@@ -225,7 +225,9 @@ local function node_colorize (head, current_color, nested)
 
         if n_id == hlist_t or n_id == vlist_t then
             local n_list = getlist(n)
-            if color_props(n_list).box_colored or color_props(getnext(n_list)).box_colored then
+            if  color_props(n_list).box_colored or
+                color_props(getnext(n_list)).box_colored or
+                color_props(getnext(getnext(n_list))).box_colored then
                 if current_color then
                     head, n, current_color = color_whatsit(head, n, current_color, false)
                 end


### PR DESCRIPTION
If the issue #118 is to be dealt with in luaotfload, luaotfload-colors.lua seems to be proper place to provide new callbacks. Two callbacks `pre_mlist_to_hlist_filter` and `post_mlist_to_hlist_filter` are now provided. As they are `data`-type callbacks, users' functions should return a `newhead` as is the case of `mlist_to_hlist` callback.

Incidentally, this chance to update luaotfload-colors.lua has been abused for some minor improvements, the main change being to use node properties instead of node attributes as the former is more versatile to manage.  