### PR TITLE
harf-define: look up absolute file path in find_*_file callbacks

### DIFF
--- a/src/luaotfload-harf-define.lua
+++ b/src/luaotfload-harf-define.lua
@@ -366,9 +366,19 @@ fonts.readers.harf = function(spec)
 end
 
 luatexbase.add_to_callback('find_opentype_file', function(name)
-  return name:gsub('^harfloaded:', '')
+  local path = luaotfload.fontloader.resolvers.findfile(name)
+  if path then
+    return path
+  else
+    return name:gsub('^harfloaded:', '')
+  end
 end, 'luaotfload.harf.strip_prefix')
 
 luatexbase.add_to_callback('find_truetype_file', function(name)
-  return name:gsub('^harfloaded:', '')
+  local path = luaotfload.fontloader.resolvers.findfile(name)
+  if path then
+    return path
+  else
+    return name:gsub('^harfloaded:', '')
+  end
 end, 'luaotfload.harf.strip_prefix')

--- a/testfiles-harf/fallback.lvt
+++ b/testfiles-harf/fallback.lvt
@@ -10,6 +10,10 @@
   luatexbase.add_to_callback('glyph_info', function(n)
     return string.format('"\csstring\%s" \csstring\%04X \csstring\%+i:\csstring\%+i\string\t\csstring\%s', cb(n), n.char, n.xoffset, n.yoffset, font.getfont(n.font).specification.specification:gsub(";fallback=\csstring\%d+",";fallback=..."))
   end, 'Harf glyph_info callback -- testing variant')
+  luatexbase.add_to_callback('glyph_not_found', function(id, char)
+    texio.write_nl(string.format('Missing character: There is no \csstring\%s (U+\csstring\%04X) in font \csstring\%s!',
+                   utf8.char(char), char, font.getfont(id).specification.specification:gsub(";fallback=.*",";fallback=...")))
+  end, 'Harf glyph_not_found callback -- testing variant')
 }
 
 \directlua{luaotfload.add_fallback("myfallback", {

--- a/testfiles-harf/fallback.tlg
+++ b/testfiles-harf/fallback.tlg
@@ -73,6 +73,6 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 1.0fil
 ...\TU/lmr/m/n/10 "1" 0031 +0:+0^^I[lmroman10-regular]:+tlig;
 ...\glue 0.0 plus 1.0fil
-Missing character: There is no ฐ (U+0E10) in font [DejaVuSans.ttf]:mode=harf;-fallback;script=thai;-multiscript;fallback=8!
-Missing character: There is no ู (U+0E39) in font [DejaVuSans.ttf]:mode=harf;-fallback;script=thai;-multiscript;fallback=8!
+Missing character: There is no ฐ (U+0E10) in font [DejaVuSans.ttf]:mode=harf;-fallback;script=thai;-multiscript;fallback=...!
+Missing character: There is no ู (U+0E39) in font [DejaVuSans.ttf]:mode=harf;-fallback;script=thai;-multiscript;fallback=...!
 2 hlist, 1 rule, 1 dir, 3 kern, 1 glyph, 2 attribute, 48 glue_spec, 2 attribute_list (fallback.aux)

--- a/testfiles/issue142-ttf-from-map.pvt
+++ b/testfiles/issue142-ttf-from-map.pvt
@@ -1,0 +1,7 @@
+\input{regression-test}
+\documentclass{article}
+\usepackage[T1]{fontenc}
+\begin{document}
+\font\cuprum=cprmn8t
+\cuprum test
+\end{document}

--- a/testfiles/issue142-ttf-from-map.tpf
+++ b/testfiles/issue142-ttf-from-map.tpf
@@ -1,0 +1,80 @@
+%PDF-1.5
+%Ã’¡‘≈ÿ–ƒ∆
+3 0 obj
+<< /Length 115 >>        
+stream
+BT
+/F27 9.96264 Tf
+1 0 0 1 148.712 707.125 Tm [(t)10(est)]TJ
+/F26 9.96264 Tf
+1 0 0 1 303.133 139.255 Tm [(1)]TJ
+ET
+endstream
+endobj
+2 0 obj
+<< /Type /Page /Contents 3 0 R /Resources 1 0 R /MediaBox [ 0 0 595.276 841.89 ] /Parent 6 0 R >>
+endobj
+1 0 obj
+<< /Font << /F27 4 0 R /F26 5 0 R >> /ProcSet [ /PDF /Text ] >>
+endobj
+8 0 obj
+[500 ]
+endobj
+9 0 obj
+[440 0 0 0 0 0 0 0 0 0 0 0 0 0 395 345 ]
+endobj
+11 0 obj
+<< /Length1 4400 /Length 4400 >>       
+[BINARY STREAM]
+endobj
+10 0 obj
+<< /Type /FontDescriptor /FontName /CGNUEO+Cuprum-Regular /Flags 4 /FontBBox [ -70 -220 960 890 ] /Ascent 890 /CapHeight 690 /Descent -260 /ItalicAngle 0 /StemV 57 /XHeight 500 /FontFile2 11 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /TrueType /BaseFont /CGNUEO+Cuprum-Regular /FontDescriptor 10 0 R /FirstChar 101 /LastChar 116 /Widths 9 0 R >>
+endobj
+13 0 obj
+<< /Length1 1643 /Length2 14632 /Length3 0 /Length 16275 >>      
+[BINARY STREAM]
+endobj
+12 0 obj
+<< /Type /FontDescriptor /FontName /JVWJQI+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 689 /CapHeight 689 /Descent -194 /ItalicAngle 0 /StemV 69 /XHeight 431 /CharSet( /one) /FontFile 13 0 R >>
+endobj
+7 0 obj
+<< /Type /Encoding /Differences [ 49 /one ] >>
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /JVWJQI+LMRoman10-Regular /FontDescriptor 12 0 R /FirstChar 49 /LastChar 49 /Widths 8 0 R /Encoding 7 0 R >>
+endobj
+6 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 2 0 R ] >>
+endobj
+14 0 obj
+<< /Type /Catalog /Pages 6 0 R >>
+endobj
+15 0 obj
+<< /Producer (LuaTeX) /Creator (TeX) /Trapped /False >>
+endobj
+xref
+0 16
+0000000000 65535 f 
+0000000307 00000 n 
+0000000194 00000 n 
+0000000020 00000 n 
+0000005152 00000 n 
+0000021975 00000 n 
+0000022140 00000 n 
+0000021913 00000 n 
+0000000386 00000 n 
+0000000408 00000 n 
+0000004938 00000 n 
+0000000464 00000 n 
+0000021678 00000 n 
+0000005303 00000 n 
+0000022200 00000 n 
+0000022250 00000 n 
+trailer
+<< /Size 16 /Root 14 0 R /Info 15 0 R >>
+startxref
+22322
+%%EOF

--- a/texlive.sh
+++ b/texlive.sh
@@ -44,14 +44,14 @@ echo graphics xcolor graphics-def pgf
 
 # fonts support - perhaps take here luaotfload out of the list ...
 # or is it installed as dependency anyway?
-echo fontspec microtype unicode-math luaotfload
+echo fontspec microtype unicode-math luaotfload ttfutils
 
 # fonts
 echo sourcecodepro Asana-Math  ebgaramond  tex-gyre  amsfonts gnu-freefont
 echo opensans fira tex-gyre-math junicode lm  lm-math amiri ipaex xits
 echo libertine coelacanth fontawesome stix2-otf dejavu
 echo luatexko unfonts-core cjk-ko iwona libertinus-fonts fandol
-echo cm-unicode noto
+echo cm-unicode noto cuprum
 
 # languages
 echo luatexja arabluatex babel babel-english


### PR DESCRIPTION
My attempt at fixing #142 by looking up the full file path using Kpathsea. I am not sure whether this is the right approach or if it potentially breaks other ways of specifying fonts, but it worked fine in all my test cases, including the example from the linked issue and the downstream bug report.