### PR TITLE
[RFC] Don't follow symlinks when normalizing paths

### DIFF
--- a/src/luaotfload-database.lua
+++ b/src/luaotfload-database.lua
@@ -176,7 +176,6 @@ local utf8offset               = utf8.offset
 local context_environment      = luaotfload.fontloader
 local caches                   = context_environment.caches
 local filebasename             = file.basename
-local filecollapsepath         = file.collapsepath or file.collapse_path
 local filedirname              = file.dirname
 local fileextname              = file.extname
 local fileiswritable           = file.iswritable
@@ -1958,8 +1957,7 @@ do
     --- choose a normalization function in advance
     --- instead of testing with every call
     local os_type, os_name = os.type, os.name
-    local filecollapsepath = filecollapsepath
-    local lfsreadlink      = lfs.readlink
+    local filecollapsepath = file.collapsepath or file.collapse_path
 
     --- windows and dos
     if os_type == "windows" or os_type == "msdos" then
@@ -1977,20 +1975,7 @@ do
 --doc]]--
 
     else -- posix
-        function path_normalize (path)
-            local dest = lfsreadlink(path)
-            if dest then
-                if kpsereadable_file(dest) then
-                    path = dest
-                elseif kpsereadable_file(filejoin(filedirname(path), dest)) then
-                    path = filejoin(file.dirname(path), dest)
-                else
-                    -- broken symlink?
-                end
-            end
-            path = filecollapsepath(path)
-            return path
-        end
+        path_normalize = filecollapsepath
     end
 end
 


### PR DESCRIPTION
Originally luaotfload tried to resolve symbolic links while normalizing paths.

I suggest to remove that logic for basically three reasons:

  1. It never fully worked anyway. The old code completely ignored directory symlinks (which in my experience are actually more common) and multi-level symlinks.
  2. In the cases where we actually normalize paths, potential symlink names might be even more useful then the resolved names. Especially it is used when filtering out the current working directory (if a path is in the searchpath which just happens to symlink to the current dir then the current dir should be searched anyway, we filter only to avoid getting triggered by the searchpath including `.`.
  The other use is for detected font file names. While this could sometimes lead to duplication there, that's not a big issue and it's not good to have paths refer outside of our regular searchpath, that could lead to issues if the symlinks get updated.
  3. luametatex doesn't have `lfs.symlinkattributes` which is required to support this.