### PR TITLE
Use `show_path` instead of `expand_path`

### DIFF
--- a/src/luaotfload-database.lua
+++ b/src/luaotfload-database.lua
@@ -2331,8 +2331,7 @@ local path_separator = os.type == "windows" and ";" or ":"
 --[[doc--
 
     collect_font_filenames_texmf -- Scan texmf tree for font files
-    relying on the kpathsea variables $OPENTYPEFONTS and $TTFONTS of
-    texmf.cnf.
+    relying on kpathsea search paths for the respective file types.
     The current working directory comes as “.” (texlive) or absolute
     path (miktex) and will always be filtered out.
 
@@ -2358,16 +2357,19 @@ local function collect_font_filenames_texmf ()
         end
     end
 
-    fontdirs = kpseexpand_path "$OPENTYPEFONTS"
-    fontdirs = fontdirs .. path_separator .. kpseexpand_path "$TTFONTS"
-    fontdirs = fontdirs .. path_separator .. kpseexpand_path "$T1FONTS"
-    fontdirs = fontdirs .. path_separator .. kpseexpand_path "$AFMFONTS"
+    local kpseshow_expanded_path = function (file_type) return kpse.expand_path (kpse.show_path (file_type)) end
 
-    if stringis_empty (fontdirs) then
+    fontdirs = kpseshow_expanded_path "opentype fonts"
+    fontdirs = fontdirs .. path_separator .. kpseshow_expanded_path "truetype fonts"
+    fontdirs = fontdirs .. path_separator .. kpseshow_expanded_path "type1 fonts"
+    fontdirs = fontdirs .. path_separator .. kpseshow_expanded_path "afm"
+
+    fontdirs  = filesplitpath (fontdirs)
+    if not fontdirs then
         return { }
     end
 
-    local tasks = filter_out_pwd (filesplitpath (fontdirs))
+    local tasks = filter_out_pwd (fontdirs)
     logreport ("both", 3, "db",
                "Initiating scan of %d directories.", #tasks)
 


### PR DESCRIPTION
`kpse.show_path` is more accurate if we want a search path for a
particular file type. Kpathsea then handles by itself what variables to
use.

Additionally this works better for the case when variables associated to
file types (e.g. $TTFONTS) are not set anywhere (neither in the
envirnment, nor in configuration file), because compile time default
paths are used.

Checking for emptiness of `fontdirs` doesn't handle the case when all
the expansions are empty. The final value of `fontdirs` would be ':::'
(or ';;;') and that slips the emptiness check. This is now handled by
checking the result of `filesplitpath`, so even the unlikely case when
all the compile time defaults are empty is covered.

Funnily enough, when I tried to comply with the coding style and used
`local kpseshow_path = kpse.show_path`, it failed with: 'too many local
variables (limit is 200)'. So I used the longer form.