### PR TITLE
Fix string formatting of version number

### DIFF
--- a/src/luaotfload-init.lua
+++ b/src/luaotfload-init.lua
@@ -394,7 +394,7 @@ local function init_main(early_hook)
   ---load_fontloader_module "font-odv.lua" --- <= Devanagari support from Context
 
   logreport ("log", 0, "init",
-             "Context OpenType loader version %q",
+             "Context OpenType loader version %.3f",
              fonts.handlers.otf.version)
   callback.register = trapped_register
   nodes = context_environment.nodes


### PR DESCRIPTION
According to Lua 5.3 manual %q is for formatting strings and escaping
them so that they can be read again by Lua. This particular number is
however floating point and %q chooses to format it like with %a, that
means hexadecimal. This greatly reduces the the readability. Better
option seems to be using %s, which uses `tostring` function.

This is the difference in output:
```
luaotfload | init : Context OpenType loader version 0x1.8e76c8b439581p+1
luaotfload | init : Context OpenType loader version 3.113
```

There may be other places where this issue may be relevant, but this
line is printed to every log file.

Most of the tests failed on me, but it doesn't seem to be a problem
with this patch.

If you choose to accept this PR consider [rebase merging](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#rebase-and-merge-your-pull-request-commits).