### PR TITLE
Replace non-breaking space by ordinary space

### DIFF
--- a/src/luaotfload-database.lua
+++ b/src/luaotfload-database.lua
@@ -2368,7 +2368,7 @@ local function collect_font_filenames_texmf ()
     fontdirs = fontdirs .. path_separator .. expanded_path "type1 fonts"
     fontdirs = fontdirs .. path_separator .. expanded_path "afm"
 
-    fontdirs = filesplitpath (fontdirs) or { }
+    fontdirs = filesplitpath (fontdirs) or { }
 
     local tasks = filter_out_pwd (fontdirs)
     logreport ("both", 3, "db",


### PR DESCRIPTION
The space between braces on the changed line was actually a non-breaking
space ("c2 a0" in UTF-8). In normal Lua such byte sequence is illegal in
that place.

But in LuaTeX it is actually interpreted as an identifier -- in this
case a global variable evaluating to "nil" and the resulting table being
"{nil}".

I am sorry for bothering with such simple things, but while it may seem
harmless, the fix is easy and the result hopefully futureproof.

I didn't check other places for similiar accidental identifiers. Hopefully
there aren't any.
