### PR TITLE
Allow keeping "weird" names

### DIFF
--- a/doc/luaotfload.conf.rst
+++ b/doc/luaotfload.conf.rst
@@ -228,6 +228,8 @@ Section ``misc``
 +---------------+--------+-------------------------+
 |  version      |   s    |  <Luaotfload version>   |
 +---------------+--------+-------------------------+
+|  keepnames    |   b    |  ``true``               |
++---------------+--------+-------------------------+
 
 With ``statistics`` enabled, extra statistics will be collected during
 index creation and appended to the index file. It may then be queried
@@ -240,6 +242,10 @@ terminal dimensions cannot be retrieved.
 
 The value of ``version`` is derived from the version string hard-coded
 in the Luaotfload source. Override at your own risk.
+
+The ``keepnames`` option decides if the ConTeXt fontloader should keep
+names it considers useless or if they should be discarded. This option
+only takes effect after font caches are regenererated.
 
 
 Section ``paths``

--- a/src/luaotfload-configuration.lua
+++ b/src/luaotfload-configuration.lua
@@ -218,6 +218,7 @@ local default_config = {
     version        = luaotfload.version,
     statistics     = false,
     termwidth      = nil,
+    keepnames      = true,
   },
   paths = {
     names_dir           = "names",
@@ -611,6 +612,7 @@ local option_spec = {
         return w
       end,
     },
+    keepnames       = { in_t = boolean_t, },
   },
   paths = {
     names_dir           = { in_t = string_t, },

--- a/src/luaotfload-init.lua
+++ b/src/luaotfload-init.lua
@@ -551,10 +551,16 @@ local function init_post_load_agl ()
 
 end
 
+local function init_post_apply_keepnames ()
+  local keepnames = config.luaotfload.misc.keepnames
+  luaotfload.fontloader.fonts.privateoffsets.keepnames = keepnames
+end
+
 --- (unit -> unit) list
 local init_post_actions = {
   init_post_install_callbacks,
   init_post_load_agl,
+  init_post_apply_keepnames
 }
 
 --- unit -> size_t


### PR DESCRIPTION
The fontloader sometimes discards glyph names it considers "weird" or "useless", especially when they have the form "uni01AB" / "u01AB" and similar. Every now and then this leads to issues, either people want to use glyphnames even if they are automatically generated (e.g. #198) or normal glyphnames just happen to look like automatic ones (e.g. in Font Awesome 5 I had some glyphs with names which started with an `u` and the following characters happened to be between `a` and `f`, triggering the system...).

Do we want to keep all names instead? It would lead to the downside if adding more data, making especially cache creation slower and requires more memory. Especially on Windows systems which often have 32 bit LuaTeX this is bad since even without this some fonts caches fail to generate due to memory pressure.

So we have to decide:

 * Do we want to keep all names by default?
 * Do we want to make this configurable? (This has the issue that the option only gets applied when the font cache gets regenerated, so especially trying to change this for only some documents would lead to very inconsistent effects. But changing it on a whole system level should be fine.)

Currently this PR implements a configuration option which defaults to keeping all names.