### PR TITLE
Consistently use `default_log_level`

### DIFF
--- a/src/luaotfload-configuration.lua
+++ b/src/luaotfload-configuration.lua
@@ -209,7 +209,7 @@ local default_config = {
     anon_sequence  = default_anon_sequence,
     resolver       = "cached",
     definer        = "patch",
-    log_level      = 0,
+    log_level      = default_log_level or 0,
     color_callback = "post_linebreak_filter",
     fontloader     = default_fontloader (),
   },


### PR DESCRIPTION
Commit message:

> There are currently two calls of `luaotfload.log.set_loglevel`:
> 
>  - The early one in `luaotfload-init.lua` that respects the free
>    `default_log_level` variable.
>  - The configuration one from `luaotfload-configuration.lua`, that
>    defaults to `0`.
> 
> This commit makes both settings respect the free `default_log_level`
> variable, thus allows disabling of logging without any configuration
> files.

I know that this is a bit controversial, but it would be useful in OpTeX and the `default_log_level` was already used in the code. Although it probably is a remnant of something and it was not meant to be overriden from outside.