### PR TITLE
Add configuration for scanning system fonts

### DIFF
--- a/src/luaotfload-configuration.lua
+++ b/src/luaotfload-configuration.lua
@@ -198,6 +198,7 @@ local default_config = {
   db = {
     formats         = "otf,ttf,ttc",
     scan_local      = false,
+    scan_system     = true,
     skip_read       = false,
     strip           = true,
     update_live     = true,
@@ -485,6 +486,7 @@ local option_spec = {
       end
     },
     scan_local   = { in_t = boolean_t, },
+    scan_system  = { in_t = boolean_t, },
     skip_read    = { in_t = boolean_t, },
     strip        = { in_t = boolean_t, },
     update_live  = { in_t = boolean_t, },
@@ -720,6 +722,7 @@ local formatters = {
     formats          = { false, format_string  },
     max_fonts        = { false, format_integer },
     scan_local       = { false, format_boolean },
+    scan_system      = { false, format_boolean },
     skip_read        = { false, format_boolean },
     strip            = { false, format_boolean },
     update_live      = { false, format_boolean },

--- a/src/luaotfload-database.lua
+++ b/src/luaotfload-database.lua
@@ -3120,7 +3120,10 @@ local function collect_font_filenames ()
     local max_fonts = config.luaotfload.db.max_fonts --- XXX revisit for lua 5.3 wrt integers
 
     tableappend (filenames, collect_font_filenames_texmf  ())
-    tableappend (filenames, collect_font_filenames_system ())
+    local scan_system = config.luaotfload.db.scan_system
+    if scan_system == nil or scan_system == true then
+       tableappend (filenames, collect_font_filenames_system ())
+    end
     local scan_local = config.luaotfload.db.scan_local == true
     if scan_local then
         local localfonts, found = collect_font_filenames_local()


### PR DESCRIPTION
To ensure that compilation results will be the same and available on different computer architectures / OS, it is reasonable to switch off system fonts collection through configuration. Compattibility with previous versions is kept.