### PR TITLE
Add configuration for xdvipsk dvi driver

### DIFF
--- a/src/luaotfload-configuration.lua
+++ b/src/luaotfload-configuration.lua
@@ -212,6 +212,7 @@ local default_config = {
     log_level      = 0,
     color_callback = "post_linebreak_filter",
     fontloader     = default_fontloader (),
+    dvi_driver     = "dvisvgm",
   },
   misc = {
     bisect         = false,
@@ -596,6 +597,11 @@ local option_spec = {
         return permissible_color_callbacks.default
       end,
     },
+    dvi_driver = {
+      in_t      = string_t,
+      out_t     = string_t,
+      transform = function (r) return r == "xdvipsk" and r or "dvisvgm" end,
+    },
   },
   misc = {
     bisect          = { in_t = boolean_t, }, --- doesn’t make sense in a config file
@@ -746,6 +752,7 @@ local formatters = {
     fontloader      = { true, format_string  },
     log_level       = { false, format_integer },
     resolver        = { false, format_string  },
+    dvi_driver      = { false, format_string  },
   },
 }
 

--- a/src/luaotfload.lua
+++ b/src/luaotfload.lua
@@ -352,7 +352,10 @@ luaotfload.main = function ()
     loadmodule "tounicode"
     loadmodule "case"
     if tex.outputmode == 0 then
-        loadmodule "dvi"          --- allow writing fonts to DVI files
+        local dvi_driver = config.luaotfload.run.dvi_driver or "dvisvgm"
+        if dvi_driver == "dvisvgm" then
+            loadmodule "dvi"          --- allow writing fonts to DVI files
+        end
     end
 
     luaotfload.aux.start_rewrite_fontname () --- to be migrated to fontspec


### PR DESCRIPTION
To restore broken compatibility with xdvipsk dvi driver in luaotfload version 3.15. Compatibility with previous default dvisvgm dvi driver remains. Example of new configuration:
[run]
  dvi-driver = xdvipsk