### PR TITLE
Set glyph width to 0 if the glyph class is "mark"

### DIFF
--- a/src/fontloader/runtime/fontloader-reference.lua
+++ b/src/fontloader/runtime/fontloader-reference.lua
@@ -18933,6 +18933,7 @@ function readers.gdef(f,fontdata,specification)
      local class=classes[readushort(f)]
      if class=="mark" then
       marks[index]=true
+      glyphs[index].width=0
      end
      glyphs[index].class=class
     end
@@ -18947,6 +18948,7 @@ function readers.gdef(f,fontdata,specification)
        glyphs[index].class=class
        if class=="mark" then
         marks[index]=true
+        glyphs[index].width=0
        end
       end
      end


### PR DESCRIPTION
In monospaced fonts, all glyphs must have the same width, including mark glyphs. In proportionally spaced fonts, those usually have a width of 0.

luaotfload currently reads the actual width for mark glyphs from the font. This results in an extra space after the mark glyph, as you can reproduce with the [Sudo Coding Font](https://github.com/jenskutilek/sudo-font):

```tex
%!TEX TS-program = lualatex
%!TEX encoding = UTF-8 Unicode

\documentclass{article}
\usepackage{fontspec}
\setromanfont{Sudo}
\begin{document}
The dashes shoud be directly next to the p:
\begin{itemize}
\item Without mark: —p—
\item With mark: —p̄—
\end{itemize}
\end{document}
```

![Bildschirmfoto 2025-01-30 um 09 08 51](https://github.com/user-attachments/assets/53d2ab62-c93b-4d6e-b8cc-3c9e9bc7424b)

This has been discovered and discussed in the [Glyphs forum](https://forum.glyphsapp.com/t/diacrtitics-change-x-between-glyphs-2-and-glyphs-3/32647/14).

This PR sets the width of mark glyphs to 0, regardless of their width in the font. The result:

![Bildschirmfoto 2025-01-30 um 09 09 56](https://github.com/user-attachments/assets/f4ea1d37-da3d-4faf-9e12-9a18518b1baf)
