### PR TITLE
More useful error message if no writeable cache path

### DIFF
--- a/src/fontloader/runtime/fontloader-basics-gen.lua
+++ b/src/fontloader/runtime/fontloader-basics-gen.lua
@@ -253,7 +253,7 @@ do
     end
 
     if not writable then
-        logs.report("system","no writeable cache path, quiting")
+        logs.report("system","no writeable cache path, quiting. Try setting TEXMFCACHE or TEXMFVAR and reading https://www.tug.org/texinfohtml/kpathsea.html#Safe-filenames")
         os.exit()
     elseif #readables == 0 then
         logs.report("system","no readable cache path, quiting")


### PR DESCRIPTION
kpathsea has some perhaps-surprising rules around "safe filenames". We attempt to make this information more discoverable by linking from the error message.

I have spent a bunch of time debugging why upgrading texlive-2023 to texlive-2025 meant I couldn't build my document via nix. The error message was rather unhelpful (yes there is a writeable cache directory, it is right there) as I was unaware of the "no hidden directories" rule. Hopefully this patch will save some time for the next person to trip across this (i.e. me in a few months time!)

Probably there is better phrasing of the additions to the message.