### PR TITLE
remove assertion of direction matching between begin/end dir nodes

### DIFF
--- a/src/luaotfload-harf-plug.lua
+++ b/src/luaotfload-harf-plug.lua
@@ -240,7 +240,6 @@ local function itemize(head, fontid, direction)
       local dir, cancel = getdirection(n)
       local direction, kind = getdirection(n)
       if cancel then
-        assert(currdir == dir)
         -- Pop the last direction from the stack.
         currdir = tableremove(dirstack)
       else


### PR DESCRIPTION
LuaTeX does not really care about the direction of an enddir node, it only consider it as a flag to pop the current dir, and restore the old one (see pdflistout.c).

I don't think luaotfload should be more restrictive then the engine.