### PR TITLE
Fix incorrect path-like splitting of texmfcnf variables

### DIFF
--- a/src/fontloader/runtime/fontloader-basics-gen.lua
+++ b/src/fontloader/runtime/fontloader-basics-gen.lua
@@ -197,18 +197,18 @@ do
 
     -- standard context tree setup
 
-    local cachepaths = kpse.expand_var('$TEXMFCACHE') or ""
+    local cachepaths = kpse.expand_braces('$TEXMFCACHE') or ""
 
     -- quite like tex live or so (the weird $TEXMFCACHE test seems to be needed on miktex)
 
     if cachepaths == "" or cachepaths == "$TEXMFCACHE" then
-        cachepaths = kpse.expand_var('$TEXMFVAR') or ""
+        cachepaths = kpse.expand_braces('$TEXMFVAR') or ""
     end
 
     -- this also happened to be used (the weird $TEXMFVAR test seems to be needed on miktex)
 
     if cachepaths == "" or cachepaths == "$TEXMFVAR" then
-        cachepaths = kpse.expand_var('$VARTEXMF') or ""
+        cachepaths = kpse.expand_braces('$VARTEXMF') or ""
     end
 
     -- and this is a last resort (hm, we could use TEMP or TEMPDIR)

--- a/src/fontloader/runtime/fontloader-reference.lua
+++ b/src/fontloader/runtime/fontloader-reference.lua
@@ -4637,12 +4637,12 @@ if not caches.namespace or caches.namespace=="" or caches.namespace=="context" t
  caches.namespace='generic'
 end
 do
- local cachepaths=kpse.expand_var('$TEXMFCACHE') or ""
+ local cachepaths=kpse.expand_braces('$TEXMFCACHE') or ""
  if cachepaths=="" or cachepaths=="$TEXMFCACHE" then
-  cachepaths=kpse.expand_var('$TEXMFVAR') or ""
+  cachepaths=kpse.expand_braces('$TEXMFVAR') or ""
  end
  if cachepaths=="" or cachepaths=="$TEXMFVAR" then
-  cachepaths=kpse.expand_var('$VARTEXMF') or ""
+  cachepaths=kpse.expand_braces('$VARTEXMF') or ""
  end
  if cachepaths=="" then
   local fallbacks={ "TMPDIR","TEMPDIR","TMP","TEMP","HOME","HOMEPATH" }


### PR DESCRIPTION
In a number of places in the source code, kpse.expand_var is used to evaluate a texmfcnf configuration variable when kpse.expand_braces would be the more correct choice. In the instances in question, kpse.expand_var is used to evaluate a texmfcnf configuration variable, and the resulting value is then split into colon- or semicolon-separated components that are then looped over (similar to how one splits the PATH environment variable into colon- or semicolon-separated components (depending upon the operating system) and loops over those components to find an executable).

If a texmfcnf variable, say A, is set to an expression containing braces, say {a,b}/c, then one clearly intends for the value of A to expand into a/c:b/c and then split into a/c and b/c. kpse.expand_var would expand A into {a,b}/c, in which case A would not be split correctly. kpse.expand_braces would expand A into a/c:b/c, which would correctly split A into a/c and b/c.